### PR TITLE
added -File argument to specify object type

### DIFF
--- a/Get-LargestFiles.ps1
+++ b/Get-LargestFiles.ps1
@@ -94,7 +94,7 @@ function Get-RootFolderSizes($path) {
     # Loop through the directories
     foreach ($directory in $subDirectories) {
         $targetDir = $path + "\" + $directory
-        $folderSize = (Get-ChildItem $targetDir -Recurse -Force -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum 2> $null
+        $folderSize = (Get-ChildItem $targetDir -Recurse -File -Force -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum 2> $null
         $folderSizeMB = "{0:N0}" -f ($folderSize / 1MB)
         $directoryTable.Add("$targetDir","$folderSizeMB")
     }


### PR DESCRIPTION
I noticed an error when running this script causing it to throw an error when scanning directories due to trying to access the `Length` property without the `-File` attribute. This error is also mentioned in [this issue](https://github.com/robwillisinfo/Get-LargestFiles/issues/1).

This PR simply adds the `-File` argument to the iteration inside of the `Get-RootFolderSizes` function to allow it to access the `Length` property for the detected files.